### PR TITLE
Strip comments during validation

### DIFF
--- a/game/utils/validation.py
+++ b/game/utils/validation.py
@@ -12,7 +12,7 @@ def verify_code(filename: str) -> ([], bool, bool):
     with open(filename, 'r') as f:
         contents = f.read()
 
-    contents = contents.splitlines()
+    contents = re.sub('"""[\\S\\s]*?"""|\'\'\'[\\S\\s]*?\'\'\'', "", contents).splitlines()
 
     illegal_imports = list()
     uses_open = False

--- a/game/utils/validation.py
+++ b/game/utils/validation.py
@@ -12,7 +12,7 @@ def verify_code(filename: str) -> ([], bool, bool):
     with open(filename, 'r') as f:
         contents = f.read()
 
-    contents = re.sub('"""[\\S\\s]*?"""|\'\'\'[\\S\\s]*?\'\'\'', "", contents).splitlines()
+    contents = re.sub("#.*$|\"\"\"[\\S\\s]*?\"\"\"|'''[\\S\\s]*?'''|\"[^\"].*?[^\\\\]\"|'[^'].*?[^\\\\]'", "", contents).splitlines()
 
     illegal_imports = list()
     uses_open = False


### PR DESCRIPTION
We had the word "from" in one of our comments. We found that our client was failing validation with an index error. These commits use a regex to strip out comments and strings to prevent this.

I am not good at regex, HOWEVER, this appears to function. I think.